### PR TITLE
Add logo feature for blog poasts

### DIFF
--- a/client/src/components/BlogPost.js
+++ b/client/src/components/BlogPost.js
@@ -1,14 +1,17 @@
 import Link from 'next/link';
 import Upvote from './Upvote';
 
-export default function BlogPost({ post_id, title, published_at, link, summary, company, supabase, ip }) {
+export default function BlogPost({ post_id, title, published_at, link, summary, company, logoUrl, supabase, ip }) {
   return (
     <Link href={link} passHref legacyBehavior>
       <a target="_blank" rel="noopener noreferrer" className="block relative max-w-md mx-auto bg-white rounded-xl shadow-lg overflow-hidden md:max-w-2xl m-1 border border-gray-200 hover:border-indigo-500 transition">
         <div className="md:flex mb-10">
           <div className="p-8">
             <div className="flex justify-between items-center">
-              <div className="tracking-wide text-sm text-indigo-500 font-semibold">{company}</div>
+              <div className="flex items-center space-x-4">
+                <img src={logoUrl} alt={''} className="h-8 w-8 object-contain" />
+                <div className="tracking-wide text-sm text-indigo-500 font-semibold">{company}</div>
+              </div>
               <div className="uppercase tracking-wide text-sm">{published_at}</div>
             </div>
             <div className="block mt-1 text-lg leading-tight font-medium">

--- a/client/src/pages/index.js
+++ b/client/src/pages/index.js
@@ -74,7 +74,7 @@ export default function Home(props) {
       // Query 'posts' table
       let query = supabase
         .from('posts')
-        .select("*", { count: "exact" })
+        .select("*, links(logo_url)", { count: "exact" })
         .order('published_at', { ascending: false })
         .order('id', { ascending: false });
 
@@ -122,7 +122,7 @@ export default function Home(props) {
 
     let query = supabase
       .from('posts')
-      .select("*", { count: "exact" })
+      .select("*, links(logo_url)", { count: "exact" })
       .order('published_at', { ascending: false })
       .order('id', { ascending: false });
 
@@ -193,6 +193,7 @@ export default function Home(props) {
             description={post.description}
             summary={post.summary}
             company={post.company}
+            logoUrl={post.links.logo_url}
             supabase={supabase}
             ip={ip}
           />


### PR DESCRIPTION
# New Feature: Blog Post Logos

## Description
This feature allows the addition of logos to blog posts. It utilizes Supabase storage buckets for logo management and requires new table relationships to link logos to their respective posts.

## Supabase Configuration
- **Storage Bucket**: A new bucket named `blog-post-logos` is required for logo storage.
- **Table Relationships**: The `company` column in the `posts` table requires a foreign link to the `links` table (or whatever you've named this table). I've added a column in the `links` table called `logo_url` which stores the Supabase Storage link to the respective company logos.

The foreign link looks like this when I hover over the `company` column in the `posts` table:

company -> public.links.company

Let me know if this feature is worth, I think it looks nice on the sister brypto site I've created. If the instructions are unclear, or the implementation sucks, please let me know :)

![logo_feature](https://github.com/ishan0102/engblogs/assets/56611737/7119f577-4ef0-4cac-b6ab-523aa4e6468f)